### PR TITLE
ci: add two-tag release workflows, dependabot, and PR template

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -37,6 +37,8 @@ The `dist/` directory **must be committed** — GitHub Actions runs the compiled
 - `ci.yml` — runs unit tests (`npm test`), builds, and checks `dist/` is up to date.
 - `pr-title.yml` — validates PR titles follow Conventional Commits format.
 - `conventional-label.yml` — auto-labels PRs based on their Conventional Commits title type.
+- `changelog.yml` — generates changelog on `u*.*.*` tag push (uses this action itself).
+- `release.yml` — creates GitHub Release and updates floating major-version tag after changelog.
 
 ## PR Convention
 
@@ -44,9 +46,7 @@ PR titles must follow Conventional Commits (e.g., `feat: ...`, `fix: ...`). Squa
 
 ## Releases
 
-1. Tag with `v1.x.x` (e.g., `v1.0.0`) and push.
-2. Create a GitHub Release from the tag. Check **"Publish this Action to the GitHub Marketplace"**.
-3. Update the floating `v1` tag to point to the latest `v1.x.x`.
+Two-tag flow: push `u1.x.x` → changelog workflow creates `v1.x.x` tag → release workflow creates GitHub Release and updates floating `v1` tag. See `CONTRIBUTING.md` for details.
 
 ## Marketplace
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "build"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+## Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add new feature`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,21 @@
+name: Generate changelog
+
+# First stage of the two-tag release flow.
+# Pushing a trigger tag (e.g., u1.2.3) starts this workflow, which updates
+# CHANGELOG.md and creates the corresponding release tag (e.g., v1.2.3).
+# The release.yml workflow then picks up from there.
+
+on:
+  push:
+    tags:
+      - "u*.*.*"
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: TaiSakuma/changelog-commit@v1
+        with:
+          trigger-tag: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release a new version
+
+# Second stage of the two-tag release flow.
+# Runs after the changelog workflow creates the release tag (e.g., v1.2.3).
+# Creates a GitHub Release, updates the floating major-version tag (e.g., v1),
+# and moves the "latest" tag.
+
+on:
+  workflow_run:
+    workflows: ["Generate changelog"]
+    types: [completed]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release tag
+        id: version
+        uses: TaiSakuma/checkout-version-tag@v1
+        with:
+          trigger-tag: ${{ github.event.workflow_run.head_branch }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ steps.version.outputs.release-tag }} \
+            --generate-notes
+
+      # Move the floating major-version tag (e.g., v1) so users who pin to
+      # it always get the latest patch release.
+      - name: Update floating major-version tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MAJOR="v$(echo '${{ steps.version.outputs.release-tag }}' | sed 's/^v//' | cut -d. -f1)"
+          git tag -f "$MAJOR" ${{ steps.version.outputs.release-tag }}
+          git push -f origin "$MAJOR"
+
+      - name: Tag latest
+        uses: EndBug/latest-tag@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,18 +74,17 @@ CI runs on push to `main` and on pull requests:
 
 ## Releasing
 
-1. Tag with `v` prefix and push:
+This project uses a two-tag release flow automated by CI:
+
+1. Tag with the `u` prefix and push:
 
    ```bash
-   git tag v1.x.x
-   git push origin v1.x.x
+   git tag u1.x.x
+   git push origin u1.x.x
    ```
 
-2. Create a GitHub Release from the tag. Check **"Publish this Action to the GitHub Marketplace"** in the release form.
+2. The **Generate changelog** workflow runs automatically, updating `CHANGELOG.md` and creating the `v1.x.x` tag.
 
-3. Update the floating major-version tag:
+3. The **Release** workflow then runs automatically, creating a GitHub Release with auto-generated notes and updating the floating major-version tag (e.g., `v1` for `v1.x.x`).
 
-   ```bash
-   git tag -f v1 v1.x.x
-   git push -f origin v1
-   ```
+> **Note:** The initial Marketplace publication must be done manually via the GitHub web UI by creating a release and checking **"Publish this Action to the GitHub Marketplace"**. Subsequent releases are listed automatically.


### PR DESCRIPTION
## Summary

- Add automated two-tag release flow (`u*.*.*` → changelog → `v*.*.*` release)
- Add Dependabot for daily GitHub Actions version checks
- Add PR template with Conventional Commits checklist
- Update CONTRIBUTING.md and CLAUDE.md to document the new release process

## Test plan

- [ ] Merge this PR
- [ ] Push a `u1.2.0` tag and verify the changelog and release workflows run correctly