### PR TITLE
fix: create changelog file before git-cliff --prepend

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,7 +101,9 @@ runs:
     # git-cliff's --prepend requires the file to already exist.
     - name: Ensure changelog file exists
       shell: bash
-      run: touch "${{ inputs.changelog-path }}"
+      run: |
+        mkdir -p "$(dirname "${{ inputs.changelog-path }}")"
+        touch "${{ inputs.changelog-path }}"
 
     - name: Run git-cliff
       uses: orhun/git-cliff-action@v4

--- a/action.yml
+++ b/action.yml
@@ -98,6 +98,11 @@ runs:
         INPUT_BODY: ${{ inputs.body }}
         INPUT_COMMIT_PARSERS: ${{ inputs.commit-parsers }}
 
+    # git-cliff's --prepend requires the file to already exist.
+    - name: Ensure changelog file exists
+      shell: bash
+      run: touch "${{ inputs.changelog-path }}"
+
     - name: Run git-cliff
       uses: orhun/git-cliff-action@v4
       with:


### PR DESCRIPTION
## Summary

- git-cliff's `--prepend` option fails with `No such file or directory` if the changelog file does not exist
- Add a `touch` step before running git-cliff to ensure the file exists

Closes #1

## Test plan

- [ ] Merge and release
- [ ] Push `u1.2.0` tag on a repo without `CHANGELOG.md` and verify the workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)