### PR TITLE
docs: add changelog entries for v1.0.0, v1.1.0, and v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,30 @@ All notable changes to this project will be documented in this file.
 
 - Migrate from npm to pnpm ([#6](https://github.com/TaiSakuma/changelog-commit/pull/6))
 
+## [1.1.1] - 2026-03-05
+
+### Bug Fixes
+
+- Create changelog file before git-cliff --prepend ([#5](https://github.com/TaiSakuma/changelog-commit/pull/5))
+
+### Build & CI
+
+- Bump actions/setup-node from 4 to 6 ([#4](https://github.com/TaiSakuma/changelog-commit/pull/4))
+- Add two-tag release workflows, dependabot, and PR template ([#2](https://github.com/TaiSakuma/changelog-commit/pull/2))
+
+## [1.1.0] - 2026-03-05
+
+### Documentation
+
+- Add CONTRIBUTING.md and update CLAUDE.md
+- Add GitHub Marketplace badge to README
+
+### Build & CI
+
+- Add PR title validation, conventional labels, and release notes config
+- Add CI workflow to run tests and check dist
+
+## [1.0.0] - 2026-03-04
+
+Initial release of the changelog-commit GitHub Action.
+


### PR DESCRIPTION
## Summary

- Add retroactive changelog entries for v1.0.0, v1.1.0, and v1.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)